### PR TITLE
fix(maintainer): drop pip cache from setup-python

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -68,7 +68,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install caretaker (thin client only)
         run: |


### PR DESCRIPTION
The thin streaming `Caretaker` workflow has no `actions/checkout` step, so `actions/setup-python@v5` with `cache: "pip"` errors out before pip ever runs:

```
##[error]No file in /home/runner/work/<repo>/<repo> matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository
```

Drop the line. The thin client installs exactly one wheel (`caretaker`) per scheduled run; pip caching adds negligible value, and adding a checkout / synthetic dependency file purely to enable cache would be more code for no benefit.

The upstream template was fixed in https://github.com/ianlintner/caretaker/pull/636. This PR ports the same one-line change to the deployed copy in this repo, since caretaker's bootstrap agent only writes templates on initial install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)